### PR TITLE
Forecast support

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,15 @@ weather data is not available, the following exception is thrown:
 fmi_weather_client.errors.NoWeatherDataError
 ```
 
+### Get a forecast
+You can get the forecast using a place name or coordinates and the behaviour is the same. The code tries to fetch
+the forecast for the next 6 days but looks like FMI provides it only for the next 3. You can also
+define the timestep between forecasts. Default is 24 hours.
+
+```python
+forecast = fmi_weather_client.forecast_by_place_name("Jäppilä, Pieksämäki")
+forecast2 = fmi_weather_client.forecast_by_coordinates(28.62406, 67.6894, timestep_hours=12)
+```
 
 ### Weather data
 Available weather information depends on the weather station. Currently supported fields: 
@@ -109,6 +118,25 @@ print('Temperature: %s' % weather.temperature)
 # Output: Temperature: 1.4 °C
 ```
 
+### Forecast data
+- Geopotential height (m)
+- Temperature (°C)
+- Pressure (hPa)
+- Humidity (%)
+- Wind direction (°)
+- Wind speed (m/s)
+- Wind U component (m/s)
+- Wind V component (m/s)
+- Wind max (m/s)
+- Wind gust (m/s)
+- Dew point (°)
+- Cloud cover (%)
+- Symbol [Documentation in Finnish](https://www.ilmatieteenlaitos.fi/latauspalvelun-pikaohje)
+- Precipitation amount 1h (mm/h)
+- Precipitation amount (mm)
+
+There are also other data regarding cloud coverage, radiation and land-sea mask. I have no idea
+what these really are so it is best to check FMI documentation. 
 
 ## Development
 

--- a/example.py
+++ b/example.py
@@ -1,4 +1,5 @@
 import fmi_weather_client
+from fmi_weather_client.models import Forecast
 
 
 def print_weather(weather):
@@ -17,14 +18,37 @@ def print_weather(weather):
     print('Cloud coverage: %s' % weather.cloud_coverage)
     print('Snow depth: %s' % weather.snow_depth)
     print('WaWa code: %s', weather.wawa)
+    print('')
+
+
+def print_forecast(station_forecast: Forecast):
+    print("Place: %s" % station_forecast.place)
+    print("Location: %s, %s" % (station_forecast.lat, station_forecast.lon))
+
+    for forecast in station_forecast.forecasts:
+        print("  Timestamp: %s" % forecast.timestamp)
+        print("  Temperature: %s" % forecast.temperature)
+        print("  Pressure: %s" % forecast.pressure)
+        print("  Humidity: %s" % forecast.humidity)
+        print("  Wind speed: %s" % forecast.wind_speed)
+        print("  Symbol: %", forecast.symbol)
+        print("  Cloud cover: %s" % forecast.cloud_cover)
+        print("  Low cloud cover: %s" % forecast.cloud_low_cover)
+        print("  Mid cloud cover: %s" % forecast.cloud_mid_cover)
+        print("  High cloud cover: %s" % forecast.cloud_high_cover)
+        print("  Precipitation amount 1h: %s" % forecast.precipitation_amount_1h)
+        print("  Precipitation amount: %s" % forecast.precipitation_amount)
+        print("  ")
 
 
 weather = fmi_weather_client.weather_by_coordinates(60.170998, 24.941325)
 weather2 = fmi_weather_client.weather_by_place_name("Kuopio")
 weather3 = fmi_weather_client.weather_multi_station(69.016989, 21.465569)
+forecast = fmi_weather_client.forecast_by_place_name("Jäppilä, Pieksämäki")
+forecast2 = fmi_weather_client.forecast_by_coordinates(28.62406, 67.6894)
 
 print_weather(weather)
-print('')
 print_weather(weather2)
-print('')
 print_weather(weather3)
+print_forecast(forecast)
+print_forecast(forecast2)

--- a/example.py
+++ b/example.py
@@ -45,7 +45,7 @@ weather = fmi_weather_client.weather_by_coordinates(60.170998, 24.941325)
 weather2 = fmi_weather_client.weather_by_place_name("Kuopio")
 weather3 = fmi_weather_client.weather_multi_station(69.016989, 21.465569)
 forecast = fmi_weather_client.forecast_by_place_name("Jäppilä, Pieksämäki")
-forecast2 = fmi_weather_client.forecast_by_coordinates(28.62406, 67.6894)
+forecast2 = fmi_weather_client.forecast_by_coordinates(28.62406, 67.6894, timestep_hours=12)
 
 print_weather(weather)
 print_weather(weather2)

--- a/fmi_weather_client/errors.py
+++ b/fmi_weather_client/errors.py
@@ -2,5 +2,9 @@ class NoWeatherDataError(Exception):
     pass
 
 
+class NoForecastDataError(Exception):
+    pass
+
+
 class ServiceError(Exception):
     pass

--- a/fmi_weather_client/forecast_parser.py
+++ b/fmi_weather_client/forecast_parser.py
@@ -1,0 +1,140 @@
+from datetime import datetime, timezone
+from typing import Dict, Any, List
+
+import xmltodict
+
+from fmi_weather_client import errors, utils
+from fmi_weather_client.models import FMIStation, FMIForecastTime, FMIForecast, Forecast, ForecastItem
+
+
+def parse_forecast(body: str):
+    """
+    Parse FMI forecast response body to dictionary and check errors
+    :param body: Forecast response body
+    :return: Response body as dictionary
+    """
+    data = _body_to_dict(body)
+    stations = _get_stations(data)
+    times = _get_forecast_times(data)
+    types = _get_forecast_variable_types(data)
+    value_sets = _get_forecast_variable_values(data)
+
+    # Combine values with types
+    typed_value_sets: List[Dict[str, float]] = []
+    for value_set in value_sets:
+        typed_value_set = {}
+        for idx, value in enumerate(value_set):
+            typed_value_set[types[idx]] = value
+        typed_value_sets.append(typed_value_set)
+
+    # Combine typed values with times
+    forecasts: List[FMIForecast] = []
+    for idx, time in enumerate(times):
+        forecasts.append(FMIForecast(time.lat, time.lon, time.timestamp, typed_value_sets[idx]))
+
+    # Build forecast objects
+    station_forecasts = []
+    for station in stations:
+        station_forecast = Forecast(station.name, station.lat, station.lon, [])
+        for forecast in forecasts:
+            if forecast.lat == station.lat and forecast.lon == station.lon and utils.is_non_empty_forecast(
+                    forecast.values):
+                station_forecast.forecasts.append(ForecastItem(forecast.timestamp, forecast.values))
+        station_forecasts.append(station_forecast)
+
+    # I always saw just one station so I guess this is fine
+    return station_forecasts[0]
+
+
+def _body_to_dict(body: str) -> Dict[str, Any]:
+    """
+    Convert FMI response body to dictionary and check errors
+    :param body: FMI response body
+    :return: Response as dictionary
+    """
+    data = xmltodict.parse(body)
+
+    # Check exception response
+    if 'ExceptionReport' in data.keys():
+        if 'No locations found for the place' in data['ExceptionReport']['Exception']['ExceptionText'][0]:
+            raise errors.NoForecastDataError
+        raise errors.ServiceError(data['ExceptionReport']['Exception']['ExceptionText'][0])
+
+    if 'wfs:member' not in data['wfs:FeatureCollection'].keys():
+        raise errors.NoForecastDataError
+
+    return data
+
+
+def _get_stations(data: Dict[str, Any]) -> List[FMIStation]:
+    """
+    Try to get station data from the response. When call is made with place name, there is only one
+    station available. For coordinate search there might be more.
+    :param data: Response data from FMI as xmltodict object
+    :return: List of stations
+    """
+
+    def parse_station_data(station_data: Dict[str, Any]) -> FMIStation:
+        name = station_data['gml:Point']['gml:name']
+        position = station_data['gml:Point']['gml:pos'].split(' ', 1)
+        return FMIStation(name,
+                          float(position[1]),
+                          float(position[0]))
+
+    stations = []
+    stations_dict = (data['wfs:FeatureCollection']['wfs:member']['omso:GridSeriesObservation']
+                         ['om:featureOfInterest']['sams:SF_SpatialSamplingFeature']['sams:shape']
+                         ['gml:MultiPoint']['gml:pointMembers'])
+
+    # xmltodict can return a list or an object depending on how many child the element has
+    if isinstance(stations_dict, list):
+        for station_dict in stations_dict:
+            station = parse_station_data(station_dict)
+            stations.append(station)
+    else:
+        stations.append(parse_station_data(stations_dict))
+
+    return stations
+
+
+def _get_forecast_times(data: Dict[str, Any]) -> List[FMIForecastTime]:
+    result = []
+    forecast_times_data_list = (data['wfs:FeatureCollection']['wfs:member']['omso:GridSeriesObservation']
+                                    ['om:result']['gmlcov:MultiPointCoverage']['gml:domainSet']
+                                    ['gmlcov:SimpleMultiPoint']['gmlcov:positions'].split('\n'))
+    for forecast_time in forecast_times_data_list:
+        parts = forecast_time.strip().replace('  ', ' ').split(' ')
+        lon = float(parts[0])
+        lat = float(parts[1])
+        timestamp = datetime.utcfromtimestamp(int(parts[2])).replace(tzinfo=timezone.utc)
+        result.append(FMIForecastTime(lat, lon, timestamp))
+
+    return result
+
+
+def _get_forecast_variable_types(data) -> List[str]:
+    result = []
+    variable_type_list = (data['wfs:FeatureCollection']['wfs:member']['omso:GridSeriesObservation']
+                              ['om:result']['gmlcov:MultiPointCoverage']['gmlcov:rangeType']['swe:DataRecord']
+                              ['swe:field'])
+
+    for variable_type in variable_type_list:
+        result.append(variable_type['@name'])
+
+    return result
+
+
+def _get_forecast_variable_values(data: Dict[str, Any]) -> List[List[float]]:
+    result = []
+    forecast_value_sets = (data['wfs:FeatureCollection']['wfs:member']['omso:GridSeriesObservation']
+                           ['om:result']['gmlcov:MultiPointCoverage']['gml:rangeSet']['gml:DataBlock']
+                           ['gml:doubleOrNilReasonTupleList'].split('\n'))
+
+    for forecast_value_set in forecast_value_sets:
+        forecast_values = forecast_value_set.strip().split(' ')
+        value_set = []
+        for value in forecast_values:
+            value_set.append(float(value))
+        result.append(value_set)
+
+    return result

--- a/fmi_weather_client/models.py
+++ b/fmi_weather_client/models.py
@@ -8,6 +8,9 @@ class FMIStation:
         self.lat = lat
         self.lon = lon
 
+    def __str__(self):
+        return "%s (%s, %s)" % (self.name, self.lat, self.lon)
+
 
 class FMIObservation:
     def __init__(self, timestamp: datetime, lat: float, lon: float):
@@ -60,3 +63,73 @@ class Weather:
         self.snow_depth: Optional[WeatherMeasurement] = try_get_value(observation, 'snow_aws', 'cm')
         # Current weather code (In Finnish: https://www.ilmatieteenlaitos.fi/latauspalvelun-pikaohje)
         self.wawa: Optional[WeatherMeasurement] = try_get_value(observation, 'wawa', '')
+
+
+class FMIForecastTime:
+    def __init__(self, lat: float, lon: float, timestamp: datetime):
+        self.lat = lat
+        self.lon = lon
+        self.timestamp = timestamp
+
+    def __str__(self):
+        return "%s, %s, %s" % (self.lat, self.lon, self.timestamp)
+
+
+class FMIForecast:
+    def __init__(self, lat: float, lon: float, timestamp: datetime, values: Dict[str, float]):
+        self.lat = lat
+        self.lon = lon
+        self.timestamp = timestamp
+        self.values = values
+
+
+class ForecastValue:
+    def __init__(self, value: float, unit: str):
+        self.value = value
+        self.unit = unit
+
+    def __str__(self):
+        return "%s %s" % (self.value, self.unit)
+
+
+class ForecastItem:
+    def __init__(self, timestamp: datetime, values: Dict[str, float]):
+
+        def try_get_value(o: Dict[str, float], variable_name: str, unit: str) -> Optional[ForecastValue]:
+            value = o.get(variable_name, None)
+            if value is not None:
+                return ForecastValue(value, unit)
+            return None
+
+        self.timestamp = timestamp
+        self.geopotential_height = try_get_value(values, 'GeopHeight', 'm')
+        self.temperature = try_get_value(values, 'Temperature', '°C')
+        self.pressure = try_get_value(values, 'Pressure', 'hPa')
+        self.humidity = try_get_value(values, 'Humidity', '%')
+        self.wind_direction = try_get_value(values, 'WindDirection', '°')
+        self.wind_speed = try_get_value(values, 'WindSpeedMS', 'm/s')
+        self.wind_u_component = try_get_value(values, 'WindUMS', 'm/s')
+        self.wind_v_component = try_get_value(values, 'WindVMS', 'm/s')
+        self.wind_max = try_get_value(values, 'MaximumWind', 'm/s')
+        self.wind_gust = try_get_value(values, 'WindGust', 'm/s')
+        self.dew_point = try_get_value(values, 'DewPoint', '°')
+        self.cloud_cover = try_get_value(values, 'TotalCloudCover', '%')
+        self.symbol = try_get_value(values, 'WeatherSymbol3', '')
+        self.cloud_low_cover = try_get_value(values, 'LowCloudCover', '%')
+        self.cloud_mid_cover = try_get_value(values, 'MediumCloudCover', '%')
+        self.cloud_high_cover = try_get_value(values, 'HighCloudCover', '%')
+        self.precipitation_amount_1h = try_get_value(values, 'Precipitation1h', 'mm/h')
+        self.precipitation_amount = try_get_value(values, 'PrecipitationAmount', 'mm')
+        self.radiation_global_short_wave_acc = try_get_value(values, 'RadiationGlobalAccumulation', 'J/m²')
+        self.radiation_global_long_wave_acc = try_get_value(values, 'RadiationLWAccumulation', 'J/m²')
+        self.radiation_surface_long_wave_acc = try_get_value(values, 'RadiationNetSurfaceLWAccumulation', 'J/m²')
+        self.radiation_diff_surface_short_wave_acc = try_get_value(values, 'RadiationDiffuseAccumulation', 'J/m²')
+        self.land_sea_mask = try_get_value(values, 'LandSeaMask', '')
+
+
+class Forecast:
+    def __init__(self, place: str, lat: float, lon: float, forecasts: List[ForecastItem]):
+        self.place = place
+        self.lat = lat
+        self.lon = lon
+        self.forecasts = forecasts

--- a/fmi_weather_client/models.py
+++ b/fmi_weather_client/models.py
@@ -60,6 +60,3 @@ class Weather:
         self.snow_depth: Optional[WeatherMeasurement] = try_get_value(observation, 'snow_aws', 'cm')
         # Current weather code (In Finnish: https://www.ilmatieteenlaitos.fi/latauspalvelun-pikaohje)
         self.wawa: Optional[WeatherMeasurement] = try_get_value(observation, 'wawa', '')
-
-        # TODO: Support wawa
-        # https://helda.helsinki.fi/bitstream/handle/10138/37284/PRO_GRADU_BOOK_HERMAN.pdf?sequence=2

--- a/fmi_weather_client/test/test_data/__init__.py
+++ b/fmi_weather_client/test/test_data/__init__.py
@@ -22,6 +22,14 @@ def mock_bbox_response(*args, **kwargs):
     return __mock_response('valid_bbox_response.xml', 200, args, kwargs)
 
 
+def mock_place_forecast_response(*args, **kwargs):
+    return __mock_response('valid_place_forecast_response.xml', 200, args, kwargs)
+
+
+def mock_coordinate_forecast_response(*args, **kwargs):
+    return __mock_response('valid_coordinate_forecast_response.xml', 200, args, kwargs)
+
+
 def mock_empty_response(*args, **kwargs):
     return __mock_response('empty_response.xml', 200, args, kwargs)
 

--- a/fmi_weather_client/test/test_data/valid_coordinate_forecast_response.xml
+++ b/fmi_weather_client/test/test_data/valid_coordinate_forecast_response.xml
@@ -1,0 +1,158 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wfs:FeatureCollection
+        timeStamp="2020-02-16T12:36:41Z"
+        numberMatched="1"
+        numberReturned="1"
+        xmlns:wfs="http://www.opengis.net/wfs/2.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:om="http://www.opengis.net/om/2.0"
+        xmlns:omso="http://inspire.ec.europa.eu/schemas/omso/3.0"
+        xmlns:ompr="http://inspire.ec.europa.eu/schemas/ompr/3.0"
+        xmlns:gml="http://www.opengis.net/gml/3.2"
+        xmlns:gmd="http://www.isotc211.org/2005/gmd"
+        xmlns:gco="http://www.isotc211.org/2005/gco"
+        xmlns:swe="http://www.opengis.net/swe/2.0"
+        xmlns:gmlcov="http://www.opengis.net/gmlcov/1.0"
+        xmlns:sam="http://www.opengis.net/sampling/2.0"
+        xmlns:sams="http://www.opengis.net/samplingSpatial/2.0"
+        xmlns:target="http://xml.fmi.fi/namespace/om/atmosphericfeatures/1.0"
+        xsi:schemaLocation="http://www.opengis.net/wfs/2.0 http://schemas.opengis.net/wfs/2.0/wfs.xsd
+    http://www.opengis.net/gmlcov/1.0 http://schemas.opengis.net/gmlcov/1.0/gmlcovAll.xsd
+    http://www.opengis.net/sampling/2.0 http://schemas.opengis.net/sampling/2.0/samplingFeature.xsd
+    http://www.opengis.net/samplingSpatial/2.0 http://schemas.opengis.net/samplingSpatial/2.0/spatialSamplingFeature.xsd
+    http://www.opengis.net/swe/2.0 http://schemas.opengis.net/sweCommon/2.0/swe.xsd
+    http://inspire.ec.europa.eu/schemas/omso/3.0 http://inspire.ec.europa.eu/schemas/omso/3.0/SpecialisedObservations.xsd
+    http://inspire.ec.europa.eu/schemas/ompr/3.0 http://inspire.ec.europa.eu/schemas/ompr/3.0/Processes.xsd
+    http://xml.fmi.fi/namespace/om/atmosphericfeatures/1.0 http://xml.fmi.fi/schema/om/atmosphericfeatures/1.0/atmosphericfeatures.xsd">
+    <wfs:member>
+        <omso:GridSeriesObservation gml:id="WFS-d6ZMUFX8mIpQ96xOxivEop_GTsSJTowuYWbbpdOs2_llx4efR060aeWzDtdOufXlmw48rp1w36d3R0629dnTTw36d3THv7ZeWHPlhaWLLn07qmnbltSfwol75fdEY2PlzrUi0Kcd06aMmrhnZd2Spp25bUn8KJq.X3RHBm07sk7Lh5ZefSth2ackhmZ8u_Tk51mNmbdowaOjXl899_LJf39svLvy09MOLZliaWzL2y7KnnhlqZmzfjw7MtambTfjSV3XpmcNbbh8RNPPph3Y8tK1dCA1tunnz07s9TL46VjTsM5lbd.TLsrM0aeWzDtZXDDyw7a1I.XfwkZdOfR0rWqZdvDLyw9OvLLWhQ5ZefPryy1oSOu3Tk09PNbVfTuyRNPLLj6ad.6tavp3ZKfDLlyTadZ1fTuyVZtOs6vp3ZK02nWtNw.NO3rtr6d2StCvp3ZI_Xn0rQiZe9Dfp3dK3qm_ph2Q9m_rkh7.2XlW5Xy4emjLyp.duLfsZ1tTN_eHs39ckPf2y8q4JuXJp67Yezf1yQ9_bLyrckac.iHs39ckPf2y8q3qHLLj08NPTD0079zHRXNQ5Zcenhp6Yemnfug7d_Xd0r2pYcmnD00790fZvxYdkHHj67euzD00791d1LDk04emnfumV4OPH129dmHpp37qwwqWHJpw9NO_dOy9KfXlmw48syvBx4.u3rsw9NO_dWGFSw5NOHpp37p2XpT68s2HHlp14OPH129dmHpp37q.KWHJpw9NO_dE05s3Xnlg48fXb12YemnfurWmYd2SnlwzcPPW3OfTfyy5OPXLy839OSvMLNt0unWbfyy48PPo6daNPLZh2unXPryzYceV064b9O7o6dbeuzpp4b9O7pj39svLDnytDpp25afTLwnhsaHTTty2t.7LWNVqQwA-">
+            <om:phenomenonTime>
+                <gml:TimePeriod gml:id="time-interval-1-1">
+                    <gml:beginPosition>2020-02-16T00:00:00Z</gml:beginPosition>
+                    <gml:endPosition>2020-02-21T12:00:00Z</gml:endPosition>
+                </gml:TimePeriod>
+            </om:phenomenonTime>
+            <om:resultTime>
+                <gml:TimeInstant gml:id="time-1-1">
+                    <gml:timePosition>2020-02-16T09:18:36Z</gml:timePosition>
+                </gml:TimeInstant>
+            </om:resultTime>
+            <om:procedure xlink:href="http://xml.fmi.fi/inspire/process/hirlam"/>
+            <om:parameter>
+                <om:NamedValue>
+                    <om:name xlink:href="http://xml.fmi.fi/inspire/process/hirlam"/>
+                    <om:value>
+                        <gml:TimeInstant gml:id="analysis-time-1-1">
+                            <gml:timePosition>2020-02-16T06:00:00Z</gml:timePosition>
+                        </gml:TimeInstant>
+                    </om:value>
+                </om:NamedValue>
+            </om:parameter>
+            <om:observedProperty  xlink:href="http://opendata.fmi.fi/meta?observableProperty=forecast&amp;param=GeopHeight,Temperature,Pressure,Humidity,WindDirection,WindSpeedMS,WindUMS,WindVMS,MaximumWind,WindGust,DewPoint,TotalCloudCover,WeatherSymbol3,LowCloudCover,MediumCloudCover,HighCloudCover,Precipitation1h,PrecipitationAmount,RadiationGlobalAccumulation,RadiationLWAccumulation,RadiationNetSurfaceLWAccumulation,RadiationNetSurfaceSWAccumulation,RadiationDiffuseAccumulation,LandSeaMask&amp;language=eng"/>
+            <om:featureOfInterest>
+                <sams:SF_SpatialSamplingFeature gml:id="enn-s-1-1-">
+                    <sam:sampledFeature>
+                        <target:LocationCollection gml:id="sampled-target-1-1">
+                            <target:member>
+                                <target:Location gml:id="forloc-geoid-637404-pos">
+                                    <gml:identifier codeSpace="http://xml.fmi.fi/namespace/stationcode/geoid">637404</gml:identifier>
+                                    <gml:name codeSpace="http://xml.fmi.fi/namespace/locationcode/name">Sauoiva</gml:name>
+                                    <gml:name codeSpace="http://xml.fmi.fi/namespace/locationcode/geoid">637404</gml:name>
+                                    <target:representativePoint xlink:href="#point-637404"/>
+                                    <target:country codeSpace="http://xml.fmi.fi/namespace/location/country">Finland</target:country>
+                                    <target:timezone>Europe/Helsinki</target:timezone>
+                                    <target:region codeSpace="http://xml.fmi.fi/namespace/location/region">Salla</target:region>
+                                </target:Location>
+                            </target:member>
+                        </target:LocationCollection>
+                    </sam:sampledFeature>
+                    <sams:shape>
+                        <gml:MultiPoint gml:id="sf-1-1-">
+                            <gml:pointMembers>
+                                <gml:Point gml:id="point-637404" srsName="http://www.opengis.net/def/crs/EPSG/0/4258" srsDimension="2">
+                                    <gml:name>Sauoiva</gml:name>
+                                    <gml:pos>67.58399 29.74273 </gml:pos>
+                                </gml:Point>
+                            </gml:pointMembers>
+                        </gml:MultiPoint>
+                    </sams:shape>
+                </sams:SF_SpatialSamplingFeature>
+            </om:featureOfInterest>
+            <om:result>
+                <gmlcov:MultiPointCoverage gml:id="mpcv-1-1">
+                    <gml:domainSet>
+                        <gmlcov:SimpleMultiPoint gml:id="mp-1-1" srsName="http://xml.fmi.fi/gml/crs/compoundCRS.php?crs=4258&amp;time=unixtime" srsDimension="3">
+                            <gmlcov:positions>
+                                67.58399 29.74273  1581811200
+                                67.58399 29.74273  1581854400
+                                67.58399 29.74273  1581897600
+                                67.58399 29.74273  1581940800
+                                67.58399 29.74273  1581984000
+                                67.58399 29.74273  1582027200
+                                67.58399 29.74273  1582070400
+                                67.58399 29.74273  1582113600
+                                67.58399 29.74273  1582156800
+                                67.58399 29.74273  1582200000
+                                67.58399 29.74273  1582243200
+                                67.58399 29.74273  1582286400
+                            </gmlcov:positions>
+                        </gmlcov:SimpleMultiPoint>
+                    </gml:domainSet>
+                    <gml:rangeSet>
+                        <gml:DataBlock>
+                            <gml:rangeParameters/>
+                            <gml:doubleOrNilReasonTupleList>
+                                NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN
+                                366.05 -2.26 991.73 95.29 168.0 2.79 -1.82 2.13 2.85 8.67 -3.17 100.0 3.0 51.6 98.6 99.9 0.0 0.1 366735.53 6782847.0 -88927.28 298585.88 367741.0 1.0
+                                366.05 0.41 968.58 94.54 159.0 3.31 -2.45 2.24 4.05 10.21 -0.66 100.0 52.0 99.9 95.4 0.0 0.7 5.8 495136.53 20289592.0 -573642.75 402490.69 495136.53 1.0
+                                366.05 0.53 958.85 97.0 253.0 3.74 2.81 2.46 4.61 11.25 -0.06 100.0 52.0 99.9 99.9 99.9 0.5 14.9 756807.88 34095544.0 -1034228.44 612327.75 760818.44 1.0
+                                366.05 1.0 968.75 97.19 253.0 4.0 2.94 2.72 4.47 11.97 0.45 100.0 51.0 94.9 82.4 98.8 0.1 16.9 822343.88 47316492.0 -2048792.13 661479.75 818162.44 1.0
+                                366.05 0.37 973.67 97.0 271.0 1.35 1.24 0.5 3.14 4.17 -0.22 100.0 51.0 99.9 39.2 99.9 0.1 20.9 1222015.13 61191096.0 -2394977.0 986206.31 1216650.75 1.0
+                                NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN
+                                NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN
+                                NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN
+                                NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN
+                                NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN
+                                NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN
+                            </gml:doubleOrNilReasonTupleList>
+                        </gml:DataBlock>
+                    </gml:rangeSet>
+                    <gml:coverageFunction>
+                        <gml:CoverageMappingRule>
+                            <gml:ruleDefinition>Linear</gml:ruleDefinition>
+                        </gml:CoverageMappingRule>
+                    </gml:coverageFunction>
+                    <gmlcov:rangeType>
+                        <swe:DataRecord>
+                            <swe:field name="GeopHeight"  xlink:href="http://opendata.fmi.fi/meta?observableProperty=forecast&amp;param=GeopHeight&amp;language=eng"/>
+                            <swe:field name="Temperature"  xlink:href="http://opendata.fmi.fi/meta?observableProperty=forecast&amp;param=Temperature&amp;language=eng"/>
+                            <swe:field name="Pressure"  xlink:href="http://opendata.fmi.fi/meta?observableProperty=forecast&amp;param=Pressure&amp;language=eng"/>
+                            <swe:field name="Humidity"  xlink:href="http://opendata.fmi.fi/meta?observableProperty=forecast&amp;param=Humidity&amp;language=eng"/>
+                            <swe:field name="WindDirection"  xlink:href="http://opendata.fmi.fi/meta?observableProperty=forecast&amp;param=WindDirection&amp;language=eng"/>
+                            <swe:field name="WindSpeedMS"  xlink:href="http://opendata.fmi.fi/meta?observableProperty=forecast&amp;param=WindSpeedMS&amp;language=eng"/>
+                            <swe:field name="WindUMS"  xlink:href="http://opendata.fmi.fi/meta?observableProperty=forecast&amp;param=WindUMS&amp;language=eng"/>
+                            <swe:field name="WindVMS"  xlink:href="http://opendata.fmi.fi/meta?observableProperty=forecast&amp;param=WindVMS&amp;language=eng"/>
+                            <swe:field name="MaximumWind"  xlink:href="http://opendata.fmi.fi/meta?observableProperty=forecast&amp;param=MaximumWind&amp;language=eng"/>
+                            <swe:field name="WindGust"  xlink:href="http://opendata.fmi.fi/meta?observableProperty=forecast&amp;param=WindGust&amp;language=eng"/>
+                            <swe:field name="DewPoint"  xlink:href="http://opendata.fmi.fi/meta?observableProperty=forecast&amp;param=DewPoint&amp;language=eng"/>
+                            <swe:field name="TotalCloudCover"  xlink:href="http://opendata.fmi.fi/meta?observableProperty=forecast&amp;param=TotalCloudCover&amp;language=eng"/>
+                            <swe:field name="WeatherSymbol3"  xlink:href="http://opendata.fmi.fi/meta?observableProperty=forecast&amp;param=WeatherSymbol3&amp;language=eng"/>
+                            <swe:field name="LowCloudCover"  xlink:href="http://opendata.fmi.fi/meta?observableProperty=forecast&amp;param=LowCloudCover&amp;language=eng"/>
+                            <swe:field name="MediumCloudCover"  xlink:href="http://opendata.fmi.fi/meta?observableProperty=forecast&amp;param=MediumCloudCover&amp;language=eng"/>
+                            <swe:field name="HighCloudCover"  xlink:href="http://opendata.fmi.fi/meta?observableProperty=forecast&amp;param=HighCloudCover&amp;language=eng"/>
+                            <swe:field name="Precipitation1h"  xlink:href="http://opendata.fmi.fi/meta?observableProperty=forecast&amp;param=Precipitation1h&amp;language=eng"/>
+                            <swe:field name="PrecipitationAmount"  xlink:href="http://opendata.fmi.fi/meta?observableProperty=forecast&amp;param=PrecipitationAmount&amp;language=eng"/>
+                            <swe:field name="RadiationGlobalAccumulation"  xlink:href="http://opendata.fmi.fi/meta?observableProperty=forecast&amp;param=RadiationGlobalAccumulation&amp;language=eng"/>
+                            <swe:field name="RadiationLWAccumulation"  xlink:href="http://opendata.fmi.fi/meta?observableProperty=forecast&amp;param=RadiationLWAccumulation&amp;language=eng"/>
+                            <swe:field name="RadiationNetSurfaceLWAccumulation"  xlink:href="http://opendata.fmi.fi/meta?observableProperty=forecast&amp;param=RadiationNetSurfaceLWAccumulation&amp;language=eng"/>
+                            <swe:field name="RadiationNetSurfaceSWAccumulation"  xlink:href="http://opendata.fmi.fi/meta?observableProperty=forecast&amp;param=RadiationNetSurfaceSWAccumulation&amp;language=eng"/>
+                            <swe:field name="RadiationDiffuseAccumulation"  xlink:href="http://opendata.fmi.fi/meta?observableProperty=forecast&amp;param=RadiationDiffuseAccumulation&amp;language=eng"/>
+                            <swe:field name="LandSeaMask"  xlink:href="http://opendata.fmi.fi/meta?observableProperty=forecast&amp;param=LandSeaMask&amp;language=eng"/>
+                        </swe:DataRecord>
+                    </gmlcov:rangeType>
+                </gmlcov:MultiPointCoverage>
+            </om:result>
+        </omso:GridSeriesObservation>
+    </wfs:member>
+</wfs:FeatureCollection>

--- a/fmi_weather_client/test/test_data/valid_place_forecast_response.xml
+++ b/fmi_weather_client/test/test_data/valid_place_forecast_response.xml
@@ -1,0 +1,158 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wfs:FeatureCollection
+        timeStamp="2020-02-16T12:30:16Z"
+        numberMatched="1"
+        numberReturned="1"
+        xmlns:wfs="http://www.opengis.net/wfs/2.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:om="http://www.opengis.net/om/2.0"
+        xmlns:omso="http://inspire.ec.europa.eu/schemas/omso/3.0"
+        xmlns:ompr="http://inspire.ec.europa.eu/schemas/ompr/3.0"
+        xmlns:gml="http://www.opengis.net/gml/3.2"
+        xmlns:gmd="http://www.isotc211.org/2005/gmd"
+        xmlns:gco="http://www.isotc211.org/2005/gco"
+        xmlns:swe="http://www.opengis.net/swe/2.0"
+        xmlns:gmlcov="http://www.opengis.net/gmlcov/1.0"
+        xmlns:sam="http://www.opengis.net/sampling/2.0"
+        xmlns:sams="http://www.opengis.net/samplingSpatial/2.0"
+        xmlns:target="http://xml.fmi.fi/namespace/om/atmosphericfeatures/1.0"
+        xsi:schemaLocation="http://www.opengis.net/wfs/2.0 http://schemas.opengis.net/wfs/2.0/wfs.xsd
+    http://www.opengis.net/gmlcov/1.0 http://schemas.opengis.net/gmlcov/1.0/gmlcovAll.xsd
+    http://www.opengis.net/sampling/2.0 http://schemas.opengis.net/sampling/2.0/samplingFeature.xsd
+    http://www.opengis.net/samplingSpatial/2.0 http://schemas.opengis.net/samplingSpatial/2.0/spatialSamplingFeature.xsd
+    http://www.opengis.net/swe/2.0 http://schemas.opengis.net/sweCommon/2.0/swe.xsd
+    http://inspire.ec.europa.eu/schemas/omso/3.0 http://inspire.ec.europa.eu/schemas/omso/3.0/SpecialisedObservations.xsd
+    http://inspire.ec.europa.eu/schemas/ompr/3.0 http://inspire.ec.europa.eu/schemas/ompr/3.0/Processes.xsd
+    http://xml.fmi.fi/namespace/om/atmosphericfeatures/1.0 http://xml.fmi.fi/schema/om/atmosphericfeatures/1.0/atmosphericfeatures.xsd">
+    <wfs:member>
+        <omso:GridSeriesObservation gml:id="WFS-AB620ZjxCDk.JTL4_TalevZ_dVyJTowuYWbbpdOs2_llx4efR060aeWzDtdOufXlmw48rp1w36d3R0629dnTTw36d3THv7ZeWHPlhaWLLn07qmnbltSfwol75fdEY2PlzrUi0Kcd06aMmrhnZd2Spp25bUn8KJq.X3RHBm07sk7Lh5ZefSth2ackhmZ8u_Tk51mNmrZwyYOjXl899_LJf39svLvy09MOLZliaWzL2y7KnnhlqZmzfjw7MtambTfjSV3XpmcNbbh8RNPPph3Y8tK1dCA1tunnz07s9TL46VjTsM5lbd.TLsrM0aeWzDtZXDDyw7a1I.XfwkZdOfR0rWqZdvDLyw9OvLLWhQ5ZefPryy1oSOu3Tk09PNbVfTuyRNPLLj6ad.6tavp3ZKfDLlyTadZ1fTuyVZtOs6vp3ZK02nWtNw.NO3rtr6d2StCvp3ZI_Xn0rQiZe9Dfp3dK3qm_ph2Q9m_rkh7.2XlW5Xy4emjLyp.duLfsZ1tTN_eHs39ckPf2y8q4JuXJp67Yezf1yQ9_bLyrckac.iHs39ckPf2y8q3qHLLj08NPTD0079zHRXNQ5Zcenhp6Yemnfug7d_Xd0r2pYcmnD00790fZvxYdkHHj67euzD00791d1LDk04emnfumV4OPH129dmHpp37qwwqWHJpw9NO_dOy9KfXlmw48syvBx4.u3rsw9NO_dWGFSw5NOHpp37p2XpT68s2HHlp14OPH129dmHpp37q.KWHJpw9NO_dE05s3Xnlg48fXb12YemnfurWmYd2SnlwzcPPW3OfTfyy5OPXLy839OSvMLNt0unWbfyy48PPo6daNPLZh2unXPryzYceV064b9O7o6dbeuzpp4b9O7pj39svLDnytDpp25afTLwnhsaHTTty2t.7LWNVqQwA-">
+            <om:phenomenonTime>
+                <gml:TimePeriod gml:id="time-interval-1-1">
+                    <gml:beginPosition>2020-02-16T00:00:00Z</gml:beginPosition>
+                    <gml:endPosition>2020-02-21T12:00:00Z</gml:endPosition>
+                </gml:TimePeriod>
+            </om:phenomenonTime>
+            <om:resultTime>
+                <gml:TimeInstant gml:id="time-1-1">
+                    <gml:timePosition>2020-02-16T09:18:36Z</gml:timePosition>
+                </gml:TimeInstant>
+            </om:resultTime>
+            <om:procedure xlink:href="http://xml.fmi.fi/inspire/process/hirlam"/>
+            <om:parameter>
+                <om:NamedValue>
+                    <om:name xlink:href="http://xml.fmi.fi/inspire/process/hirlam"/>
+                    <om:value>
+                        <gml:TimeInstant gml:id="analysis-time-1-1">
+                            <gml:timePosition>2020-02-16T06:00:00Z</gml:timePosition>
+                        </gml:TimeInstant>
+                    </om:value>
+                </om:NamedValue>
+            </om:parameter>
+            <om:observedProperty  xlink:href="http://opendata.fmi.fi/meta?observableProperty=forecast&amp;param=GeopHeight,Temperature,Pressure,Humidity,WindDirection,WindSpeedMS,WindUMS,WindVMS,MaximumWind,WindGust,DewPoint,TotalCloudCover,WeatherSymbol3,LowCloudCover,MediumCloudCover,HighCloudCover,Precipitation1h,PrecipitationAmount,RadiationGlobalAccumulation,RadiationLWAccumulation,RadiationNetSurfaceLWAccumulation,RadiationNetSurfaceSWAccumulation,RadiationDiffuseAccumulation,LandSeaMask&amp;language=eng"/>
+            <om:featureOfInterest>
+                <sams:SF_SpatialSamplingFeature gml:id="enn-s-1-1-">
+                    <sam:sampledFeature>
+                        <target:LocationCollection gml:id="sampled-target-1-1">
+                            <target:member>
+                                <target:Location gml:id="forloc-geoid-656820-pos">
+                                    <gml:identifier codeSpace="http://xml.fmi.fi/namespace/stationcode/geoid">656820</gml:identifier>
+                                    <gml:name codeSpace="http://xml.fmi.fi/namespace/locationcode/name">Iisalmi</gml:name>
+                                    <gml:name codeSpace="http://xml.fmi.fi/namespace/locationcode/geoid">656820</gml:name>
+                                    <target:representativePoint xlink:href="#point-656820"/>
+                                    <target:country codeSpace="http://xml.fmi.fi/namespace/location/country">Finland</target:country>
+                                    <target:timezone>Europe/Helsinki</target:timezone>
+                                    <target:region codeSpace="http://xml.fmi.fi/namespace/location/region">Finland</target:region>
+                                </target:Location>
+                            </target:member>
+                        </target:LocationCollection>
+                    </sam:sampledFeature>
+                    <sams:shape>
+                        <gml:MultiPoint gml:id="sf-1-1-">
+                            <gml:pointMembers>
+                                <gml:Point gml:id="point-656820" srsName="http://www.opengis.net/def/crs/EPSG/0/4258" srsDimension="2">
+                                    <gml:name>Iisalmi</gml:name>
+                                    <gml:pos>63.55915 27.19067 </gml:pos>
+                                </gml:Point>
+                            </gml:pointMembers>
+                        </gml:MultiPoint>
+                    </sams:shape>
+                </sams:SF_SpatialSamplingFeature>
+            </om:featureOfInterest>
+            <om:result>
+                <gmlcov:MultiPointCoverage gml:id="mpcv-1-1">
+                    <gml:domainSet>
+                        <gmlcov:SimpleMultiPoint gml:id="mp-1-1" srsName="http://xml.fmi.fi/gml/crs/compoundCRS.php?crs=4258&amp;time=unixtime" srsDimension="3">
+                            <gmlcov:positions>
+                                63.55915 27.19067  1581811200
+                                63.55915 27.19067  1581854400
+                                63.55915 27.19067  1581897600
+                                63.55915 27.19067  1581940800
+                                63.55915 27.19067  1581984000
+                                63.55915 27.19067  1582027200
+                                63.55915 27.19067  1582070400
+                                63.55915 27.19067  1582113600
+                                63.55915 27.19067  1582156800
+                                63.55915 27.19067  1582200000
+                                63.55915 27.19067  1582243200
+                                63.55915 27.19067  1582286400
+                            </gmlcov:positions>
+                        </gmlcov:SimpleMultiPoint>
+                    </gml:domainSet>
+                    <gml:rangeSet>
+                        <gml:DataBlock>
+                            <gml:rangeParameters/>
+                            <gml:doubleOrNilReasonTupleList>
+                                NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN
+                                105.03 1.21 992.1 96.49 166.0 5.31 -3.17 4.27 5.38 13.0 0.52 100.0 82.0 99.6 99.9 93.8 1.0 2.2 566599.88 7066252.5 -79389.69 373366.66 565823.06 0.75
+                                105.03 3.71 974.67 95.2 202.0 6.09 -0.34 6.09 6.39 14.83 2.75 100.0 31.0 99.9 1.6 99.9 0.2 9.0 659396.75 21453204.0 52618.24 432397.75 659396.75 0.75
+                                105.03 3.52 975.22 68.13 253.0 5.35 4.07 3.49 5.4 13.29 -3.82 82.02 2.0 80.7 19.1 16.2 0.0 9.3 3073639.25 34619964.0 -1171872.13 2058793.0 2891207.5 0.75
+                                105.03 1.81 982.12 84.07 207.0 4.09 0.23 4.1 5.08 10.18 -1.52 93.51 3.0 77.9 3.8 0.0 0.0 9.4 3955907.25 46463388.0 -3631405.0 2639325.0 3759898.75 0.75
+                                105.03 2.34 976.49 96.31 202.0 3.52 -0.13 3.52 4.23 8.85 1.61 100.0 31.0 99.9 96.6 29.3 0.3 11.0 4564224.0 60773616.0 -3637929.75 3056518.25 4369864.0 0.75
+                                NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN
+                                NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN
+                                NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN
+                                NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN
+                                NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN
+                                NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN
+                            </gml:doubleOrNilReasonTupleList>
+                        </gml:DataBlock>
+                    </gml:rangeSet>
+                    <gml:coverageFunction>
+                        <gml:CoverageMappingRule>
+                            <gml:ruleDefinition>Linear</gml:ruleDefinition>
+                        </gml:CoverageMappingRule>
+                    </gml:coverageFunction>
+                    <gmlcov:rangeType>
+                        <swe:DataRecord>
+                            <swe:field name="GeopHeight"  xlink:href="http://opendata.fmi.fi/meta?observableProperty=forecast&amp;param=GeopHeight&amp;language=eng"/>
+                            <swe:field name="Temperature"  xlink:href="http://opendata.fmi.fi/meta?observableProperty=forecast&amp;param=Temperature&amp;language=eng"/>
+                            <swe:field name="Pressure"  xlink:href="http://opendata.fmi.fi/meta?observableProperty=forecast&amp;param=Pressure&amp;language=eng"/>
+                            <swe:field name="Humidity"  xlink:href="http://opendata.fmi.fi/meta?observableProperty=forecast&amp;param=Humidity&amp;language=eng"/>
+                            <swe:field name="WindDirection"  xlink:href="http://opendata.fmi.fi/meta?observableProperty=forecast&amp;param=WindDirection&amp;language=eng"/>
+                            <swe:field name="WindSpeedMS"  xlink:href="http://opendata.fmi.fi/meta?observableProperty=forecast&amp;param=WindSpeedMS&amp;language=eng"/>
+                            <swe:field name="WindUMS"  xlink:href="http://opendata.fmi.fi/meta?observableProperty=forecast&amp;param=WindUMS&amp;language=eng"/>
+                            <swe:field name="WindVMS"  xlink:href="http://opendata.fmi.fi/meta?observableProperty=forecast&amp;param=WindVMS&amp;language=eng"/>
+                            <swe:field name="MaximumWind"  xlink:href="http://opendata.fmi.fi/meta?observableProperty=forecast&amp;param=MaximumWind&amp;language=eng"/>
+                            <swe:field name="WindGust"  xlink:href="http://opendata.fmi.fi/meta?observableProperty=forecast&amp;param=WindGust&amp;language=eng"/>
+                            <swe:field name="DewPoint"  xlink:href="http://opendata.fmi.fi/meta?observableProperty=forecast&amp;param=DewPoint&amp;language=eng"/>
+                            <swe:field name="TotalCloudCover"  xlink:href="http://opendata.fmi.fi/meta?observableProperty=forecast&amp;param=TotalCloudCover&amp;language=eng"/>
+                            <swe:field name="WeatherSymbol3"  xlink:href="http://opendata.fmi.fi/meta?observableProperty=forecast&amp;param=WeatherSymbol3&amp;language=eng"/>
+                            <swe:field name="LowCloudCover"  xlink:href="http://opendata.fmi.fi/meta?observableProperty=forecast&amp;param=LowCloudCover&amp;language=eng"/>
+                            <swe:field name="MediumCloudCover"  xlink:href="http://opendata.fmi.fi/meta?observableProperty=forecast&amp;param=MediumCloudCover&amp;language=eng"/>
+                            <swe:field name="HighCloudCover"  xlink:href="http://opendata.fmi.fi/meta?observableProperty=forecast&amp;param=HighCloudCover&amp;language=eng"/>
+                            <swe:field name="Precipitation1h"  xlink:href="http://opendata.fmi.fi/meta?observableProperty=forecast&amp;param=Precipitation1h&amp;language=eng"/>
+                            <swe:field name="PrecipitationAmount"  xlink:href="http://opendata.fmi.fi/meta?observableProperty=forecast&amp;param=PrecipitationAmount&amp;language=eng"/>
+                            <swe:field name="RadiationGlobalAccumulation"  xlink:href="http://opendata.fmi.fi/meta?observableProperty=forecast&amp;param=RadiationGlobalAccumulation&amp;language=eng"/>
+                            <swe:field name="RadiationLWAccumulation"  xlink:href="http://opendata.fmi.fi/meta?observableProperty=forecast&amp;param=RadiationLWAccumulation&amp;language=eng"/>
+                            <swe:field name="RadiationNetSurfaceLWAccumulation"  xlink:href="http://opendata.fmi.fi/meta?observableProperty=forecast&amp;param=RadiationNetSurfaceLWAccumulation&amp;language=eng"/>
+                            <swe:field name="RadiationNetSurfaceSWAccumulation"  xlink:href="http://opendata.fmi.fi/meta?observableProperty=forecast&amp;param=RadiationNetSurfaceSWAccumulation&amp;language=eng"/>
+                            <swe:field name="RadiationDiffuseAccumulation"  xlink:href="http://opendata.fmi.fi/meta?observableProperty=forecast&amp;param=RadiationDiffuseAccumulation&amp;language=eng"/>
+                            <swe:field name="LandSeaMask"  xlink:href="http://opendata.fmi.fi/meta?observableProperty=forecast&amp;param=LandSeaMask&amp;language=eng"/>
+                        </swe:DataRecord>
+                    </gmlcov:rangeType>
+                </gmlcov:MultiPointCoverage>
+            </om:result>
+        </omso:GridSeriesObservation>
+    </wfs:member>
+</wfs:FeatureCollection>

--- a/fmi_weather_client/test/test_fmi_weather.py
+++ b/fmi_weather_client/test/test_fmi_weather.py
@@ -63,6 +63,28 @@ class FMIWeatherTest(unittest.TestCase):
         with self.assertRaises(ServiceError):
             fmi_weather_client.weather_by_coordinates(27.31317, 63.14343)
 
+    @mock.patch('requests.get', side_effect=test_data.mock_place_forecast_response)
+    def test_get_forecast_by_place_name(self, mock_get):
+        forecast = fmi_weather_client.forecast_by_place_name('Iisalmi')
+        self.assertEqual(forecast.place, 'Iisalmi')
+        self.assertEqual(forecast.lat, 27.19067)
+        self.assertEqual(forecast.lon, 63.55915)
+        self.assertEqual(len(forecast.forecasts), 5)
+        self.assertEqual(forecast.forecasts[0].temperature.value, 1.21)
+        self.assertEqual(forecast.forecasts[1].pressure.value, 974.67)
+        self.assertEqual(forecast.forecasts[4].humidity.value, 96.31)
+
+    @mock.patch('requests.get', side_effect=test_data.mock_coordinate_forecast_response)
+    def test_get_forecast_by_coordinates(self, mock_get):
+        forecast = fmi_weather_client.forecast_by_coordinates(29.742731, 67.583988)
+        self.assertEqual(forecast.place, 'Sauoiva')
+        self.assertEqual(forecast.lat, 29.74273)
+        self.assertEqual(forecast.lon, 67.58399)
+        self.assertEqual(len(forecast.forecasts), 5)
+        self.assertEqual(forecast.forecasts[0].temperature.value, -2.26)
+        self.assertEqual(forecast.forecasts[1].pressure.value, 968.58)
+        self.assertEqual(forecast.forecasts[4].humidity.value, 97.0)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/fmi_weather_client/utils.py
+++ b/fmi_weather_client/utils.py
@@ -1,5 +1,5 @@
 import math
-from typing import Optional, Any
+from typing import Optional, Any, Dict
 
 from fmi_weather_client.models import FMIObservation
 
@@ -28,4 +28,12 @@ def is_non_empty_observation(observation: FMIObservation) -> bool:
     for _, value in observation.variables.items():
         if value is not None:
             return True
+    return False
+
+
+def is_non_empty_forecast(forecast: Dict[str, float]) -> bool:
+    for _, value in forecast.items():
+        if not math.isnan(value):
+            return True
+
     return False

--- a/fmi_weather_client/weather_parser.py
+++ b/fmi_weather_client/weather_parser.py
@@ -109,8 +109,8 @@ def _get_stations(data: Dict[str, Any]) -> List[FMIStation]:
 
     stations = []
     stations_dict = (data['wfs:FeatureCollection']['wfs:member']['omso:GridSeriesObservation']
-                     ['om:featureOfInterest']['sams:SF_SpatialSamplingFeature']['sams:shape']['gml:MultiPoint']
-                     ['gml:pointMember'])
+                         ['om:featureOfInterest']['sams:SF_SpatialSamplingFeature']['sams:shape']
+                         ['gml:MultiPoint']['gml:pointMember'])
 
     # xmltodict can return a list or an object depending on how many child the element has
     if isinstance(stations_dict, list):


### PR DESCRIPTION
Add a support for FMI forecasts. Looks like forecasts are available only for the next three days. FMI's own website provides forecasts for the next 10 days but I didn't find out any way to get the same information via API.