### PR TITLE
Change weather model to be Harmonie

### DIFF
--- a/fmi_weather_client/http.py
+++ b/fmi_weather_client/http.py
@@ -97,7 +97,7 @@ def _create_params(request_type: RequestType,
         'service': 'WFS',
         'version': '2.0.0',
         'request': 'getFeature',
-        'storedquery_id': 'fmi::forecast::hirlam::surface::point::multipointcoverage',
+        'storedquery_id': 'fmi::forecast::harmonie::surface::point::multipointcoverage',
         'timestep': timestep_minutes,
         'starttime': start_time.isoformat(timespec='seconds'),
         'endtime': end_time.isoformat(timespec='seconds')


### PR DESCRIPTION
Support for the old Hirlam weather model is going to end in September 2022. See issue #39 . Fixes #39 by transitioning to the recommended Harmonie weather model.

From FMI website (https://en.ilmatieteenlaitos.fi/hirlam-opendata-on-aws-s3):

> The use of the HIRLAM weather forecasting model at the Finnish Meteorological Institute will be discontinued in September 2022, after which its forecasts are no longer available through the open data services.
>
> During the past fifteen years, the main focus in forecast model development has been on a more accurate model with improved resolution. The resulting HARMONIE (MEPS) model is capable of 2.5 km horizontal resolution (compared to 7.5 km of HIRLAM) and able to predict small scale phenomena more accurately. HARMONIE (MEPS) forecasts are now available through the open data services.
>
> More information will be made available later, but already now it is worth switching to use HARMONIE (MEPS) model if possible.