### PR TITLE
Update to 10 day forcast

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ except ServerError as err:
 ```
 
 You can get the forecasts using the following functions:
-- `forecast_by_place_name(place_name, [timestep_hours=24])`
-- `forecast_by_coordinates(latitude, longitude, [timestep_hours=24])`
+- `forecast_by_place_name(place_name, [timestep_hours=24], [forecast_points = 4])`
+- `forecast_by_coordinates(latitude, longitude, [timestep_hours=24], [forecast_points = 4])`
 
 Example:
 ```python

--- a/fmi_weather_client/__init__.py
+++ b/fmi_weather_client/__init__.py
@@ -64,47 +64,51 @@ async def async_weather_by_place_name(name: str) -> Weather:
     return await loop.run_in_executor(None, weather_by_place_name, name)
 
 
-def forecast_by_place_name(name: str, timestep_hours: int = 24):
+def forecast_by_place_name(name: str, timestep_hours: int = 24, forecast_points: int = 4):
     """
     Get the latest forecast by place name.
     :param name: Place name
     :param timestep_hours: Hours between forecasts
+    :param forecast_points: number of forcast points
     :return: Latest forecast
     """
-    response = http.request_forecast_by_place(name, timestep_hours)
+    response = http.request_forecast_by_place(name, timestep_hours, forecast_points)
     return forecast_parser.parse_forecast(response)
 
 
-async def async_forecast_by_place_name(name: str, timestep_hours: int = 24):
+async def async_forecast_by_place_name(name: str, timestep_hours: int = 24, forecast_points: int = 4):
     """
     Get the latest forecast by place name asynchronously.
     :param name: Place name
     :param timestep_hours: Hours between forecasts
+    :param forecast_points: number of forcast points
     :return: Latest forecast
     """
     loop = asyncio.get_event_loop()
-    return await loop.run_in_executor(None, forecast_by_place_name, name, timestep_hours)
+    return await loop.run_in_executor(None, forecast_by_place_name, name, timestep_hours, forecast_points)
 
 
-def forecast_by_coordinates(lat: float, lon: float, timestep_hours: int = 24):
+def forecast_by_coordinates(lat: float, lon: float, timestep_hours: int = 24, forecast_points: int = 4):
     """
     Get the latest forecast by coordinates
     :param lat: Latitude (e.g. 25.67087)
     :param lon: Longitude (e.g. 62.39758)
     :param timestep_hours: Hours between forecasts
+    :param forecast_points: number of forcast points
     :return: Latest forecast
     """
-    response = http.request_forecast_by_coordinates(lat, lon, timestep_hours)
+    response = http.request_forecast_by_coordinates(lat, lon, timestep_hours, forecast_points)
     return forecast_parser.parse_forecast(response)
 
 
-async def async_forecast_by_coordinates(lat: float, lon: float, timestep_hours: int = 24):
+async def async_forecast_by_coordinates(lat: float, lon: float, timestep_hours: int = 24, forecast_points: int = 4):
     """
     Get the latest forecast by coordinates
     :param lat: Latitude (e.g. 25.67087)
     :param lon: Longitude (e.g. 62.39758)
     :param timestep_hours: Hours between forecasts
+    :param forecast_points: number of forcast points
     :return: Latest forecast
     """
     loop = asyncio.get_event_loop()
-    return await loop.run_in_executor(None, forecast_by_coordinates, lat, lon, timestep_hours)
+    return await loop.run_in_executor(None, forecast_by_coordinates, lat, lon, timestep_hours, forecast_points)

--- a/fmi_weather_client/http.py
+++ b/fmi_weather_client/http.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, UTC
 from enum import Enum
 from typing import Any, Dict, Optional
 
@@ -9,7 +9,6 @@ import xmltodict
 from fmi_weather_client.errors import ClientError, ServerError
 
 _LOGGER = logging.getLogger(__name__)
-
 
 class RequestType(Enum):
     """Possible request types"""
@@ -40,41 +39,45 @@ def request_weather_by_place(place: str) -> str:
     return _send_request(params)
 
 
-def request_forecast_by_coordinates(lat: float, lon: float, timestep_hours: int = 24) -> str:
+def request_forecast_by_coordinates(lat: float, lon: float, timestep_hours: int = 24, forecast_points: int = 4) -> str:
     """
     Get the latest forecast by place coordinates
 
     :param lat: Latitude (e.g. 25.67087)
     :param lon: Longitude (e.g. 62.39758)
     :param timestep_hours: Forecast steps in hours
+    :param forecast_points: number of forcast points
     :return: Forecast response
     """
     timestep_minutes = timestep_hours * 60
-    params = _create_params(RequestType.FORECAST, timestep_minutes, lat=lat, lon=lon)
+    params = _create_params(RequestType.FORECAST, timestep_minutes, forecast_points, lat=lat, lon=lon)
     return _send_request(params)
 
 
-def request_forecast_by_place(place: str, timestep_hours: int = 24) -> str:
+def request_forecast_by_place(place: str, timestep_hours: int = 24, forecast_points: int = 4)  -> str:
     """
     Get the latest forecast by place name
 
     :param place: Place name (e.g. Kaisaniemi,Helsinki)
     :param timestep_hours: Forecast steps in hours
+    :param forecast_points: number of forcast points
     :return: Forecast response
     """
     timestep_minutes = timestep_hours * 60
-    params = _create_params(RequestType.FORECAST, timestep_minutes, place=place)
+    params = _create_params(RequestType.FORECAST, timestep_minutes, forecast_points, place=place)
     return _send_request(params)
 
 
 def _create_params(request_type: RequestType,
                    timestep_minutes: int,
+                   forecast_points: int = 4,
                    place: Optional[str] = None,
                    lat: Optional[float] = None,
                    lon: Optional[float] = None) -> Dict[str, Any]:
     """
     Create query parameters
     :param timestep_minutes: Timestamp minutes
+    :param forecast_points: number of forcast points
     :param place: Place name
     :param lat: Latitude
     :param lon: Longitude
@@ -85,11 +88,11 @@ def _create_params(request_type: RequestType,
         raise ValueError("Missing location parameter")
 
     if request_type is RequestType.WEATHER:
-        end_time = datetime.utcnow().replace(tzinfo=timezone.utc)
+        end_time = datetime.now(UTC)
         start_time = end_time - timedelta(minutes=10)
     elif request_type is RequestType.FORECAST:
-        start_time = datetime.utcnow().replace(tzinfo=timezone.utc)
-        end_time = start_time + timedelta(days=4)
+        start_time = datetime.now(UTC)
+        end_time = start_time + timedelta(minutes=timestep_minutes * forecast_points)
     else:
         raise ValueError(f"Invalid request_type {request_type}")
 
@@ -97,7 +100,7 @@ def _create_params(request_type: RequestType,
         'service': 'WFS',
         'version': '2.0.0',
         'request': 'getFeature',
-        'storedquery_id': 'fmi::forecast::harmonie::surface::point::multipointcoverage',
+        'storedquery_id': 'fmi::forecast::edited::weather::scandinavia::point::multipointcoverage',
         'timestep': timestep_minutes,
         'starttime': start_time.isoformat(timespec='seconds'),
         'endtime': end_time.isoformat(timespec='seconds'),

--- a/fmi_weather_client/http.py
+++ b/fmi_weather_client/http.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime, timedelta, UTC
+from datetime import datetime, timedelta, timezone
 from enum import Enum
 from typing import Any, Dict, Optional
 
@@ -68,6 +68,7 @@ def request_forecast_by_place(place: str, timestep_hours: int = 24, forecast_poi
     return _send_request(params)
 
 
+# pylint: disable=too-many-arguments,too-many-positional-arguments
 def _create_params(request_type: RequestType,
                    timestep_minutes: int,
                    forecast_points: int = 4,
@@ -88,10 +89,10 @@ def _create_params(request_type: RequestType,
         raise ValueError("Missing location parameter")
 
     if request_type is RequestType.WEATHER:
-        end_time = datetime.now(UTC)
+        end_time = datetime.now(timezone.utc)
         start_time = end_time - timedelta(minutes=10)
     elif request_type is RequestType.FORECAST:
-        start_time = datetime.now(UTC)
+        start_time = datetime.now(timezone.utc)
         end_time = start_time + timedelta(minutes=timestep_minutes * forecast_points)
     else:
         raise ValueError(f"Invalid request_type {request_type}")
@@ -127,7 +128,7 @@ def _send_request(params: Dict[str, Any]) -> str:
     :param params: Query parameters
     :return: Response body
     """
-    url = 'http://opendata.fmi.fi/wfs'
+    url = 'https://opendata.fmi.fi/wfs'
 
     _LOGGER.debug("GET request to %s. Parameters: %s", url, params)
     response = requests.get(url, params=params, timeout=10)

--- a/fmi_weather_client/parsers/forecast.py
+++ b/fmi_weather_client/parsers/forecast.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime, timezone
+from datetime import datetime, timezone, UTC
 from typing import Any, Dict, List, Optional
 
 import math
@@ -70,7 +70,7 @@ def _get_datetimes(data: Dict[str, Any]) -> List[datetime]:
         parts = forecast_datetime.strip().split()
         if not parts:
             continue
-        timestamp = datetime.utcfromtimestamp(int(parts[2])).replace(tzinfo=timezone.utc)
+        timestamp = datetime.fromtimestamp(int(parts[2]), UTC).replace(tzinfo=timezone.utc)
         result.append(timestamp)
 
     return result
@@ -147,7 +147,7 @@ def _create_weather_data(time, values: Dict[str, float]) -> WeatherData:
         )
 
 
-def _feels_like(vals: Dict[str, float]) -> float:
+def _feels_like(vals: Dict[str, float]) -> float | None:
     # Feels like temperature, ported from:
     # https://github.com/fmidev/smartmet-library-newbase/blob/master/newbase/NFmiMetMath.cpp#L535
     # For more documentation see:

--- a/fmi_weather_client/parsers/forecast.py
+++ b/fmi_weather_client/parsers/forecast.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import logging
-from datetime import datetime, timezone, UTC
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 import math
@@ -70,7 +72,7 @@ def _get_datetimes(data: Dict[str, Any]) -> List[datetime]:
         parts = forecast_datetime.strip().split()
         if not parts:
             continue
-        timestamp = datetime.fromtimestamp(int(parts[2]), UTC).replace(tzinfo=timezone.utc)
+        timestamp = datetime.fromtimestamp(int(parts[2]), timezone.utc).replace(tzinfo=timezone.utc)
         result.append(timestamp)
 
     return result

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="fmi-weather-client",
-    version="0.4.1",
+    version="0.5.0",
     author="Mika Hiltunen",
     author_email="saaste@gmail.com",
     description="Library for fetching weather information from Finnish Meteorological Institute (FMI)",

--- a/test/test_http.py
+++ b/test/test_http.py
@@ -9,11 +9,11 @@ class HTTPTest(unittest.TestCase):
 
     def test_create_params_missing_location(self):
         with self.assertRaises(Exception):
-            http._create_params(RequestType.WEATHER, 10, None, None, None)
+            http._create_params(RequestType.WEATHER, 10, 4, None, None, None)
 
     def test_create_params_invalid_request_type(self):
         with self.assertRaises(Exception):
-            http._create_params("UNKNOWN", 10, "Test Place", None, None)
+            http._create_params("UNKNOWN", 10, -1, "Test Place", None, None)
 
     def test_handle_errors_client_error_with_exception_text(self):
         with self.assertRaises(ClientError):


### PR DESCRIPTION
Changing storedquery_id from `fmi::forecast::harmonie::surface::point::multipointcoverage` to `fmi::forecast::edited::weather::scandinavia::point::multipointcoverage` makes it possible to request a forecast of up to 10 days (240h) instead of the 50h. The responce data is the same and can be pared as such. 

The forecast functions got an added parameter to select the number of forcast points (so forecast time is timestep_hours * forecast_points) so to use a forcast of 5 days and a forecast _step of 1h the forecast points should be 24 * 5 =  120

Also updated a couple of soon to be depricated functions in datetime