### PR TITLE
Add support to fetch observation data by place

### DIFF
--- a/fmi_weather_client/__init__.py
+++ b/fmi_weather_client/__init__.py
@@ -116,7 +116,7 @@ async def async_forecast_by_coordinates(lat: float, lon: float, timestep_hours: 
 
 def observation_by_station_id(fmi_sid: int) -> Optional[Weather]:
     """
-    Get the latest weather information of an observation station by place name.
+    Get the latest weather information of an observation station by station id.
     :param fmi_sid: Place fmiSID (https://www.ilmatieteenlaitos.fi/havaintoasemat)
     :return: Latest weather information if available, None otherwise
     """
@@ -133,9 +133,35 @@ def observation_by_station_id(fmi_sid: int) -> Optional[Weather]:
 
 async def async_observation_by_station_id(fmi_sid: int) -> Weather:
     """
-    Get the latest weather information of an observation station by place name.
+    Get the latest weather information of an observation station by station id.
     :param fmi_sid: Place fmiSID (https://www.ilmatieteenlaitos.fi/havaintoasemat)
     :return: Latest weather information if available, None otherwise
     """
     loop = asyncio.get_event_loop()
     return await loop.run_in_executor(None, observation_by_station_id, fmi_sid)
+
+
+def observation_by_place(place: str) -> Optional[Weather]:
+    """
+    Get the latest weather information by place name
+    :param place: Place name (e.g. Kaisaniemi, Helsinki)
+    :return: Latest weather information if available, None otherwise
+    """
+    response = http.request_observation_by_place(place)
+    forecast = forecast_parser.parse_fmi_response(response, RequestType.OBSERVATION)
+
+    if forecast is None or len(forecast.forecasts) == 0:
+        return None
+
+    weather_state = forecast.forecasts[-1]
+    return Weather(forecast.place, forecast.lat, forecast.lon, weather_state)
+
+
+async def async_observation_by_place(place: str) -> Optional[Weather]:
+    """
+    Get the latest weather information by place name
+    :param place: Place name (e.g. Kaisaniemi, Helsinki)
+    :return: Latest weather information if available, None otherwise
+    """
+    loop = asyncio.get_event_loop()
+    return await loop.run_in_executor(None, observation_by_place, place)

--- a/fmi_weather_client/http.py
+++ b/fmi_weather_client/http.py
@@ -74,6 +74,17 @@ def request_observation_by_station_id(fmi_sid: int) -> str:
     return _send_request(params)
 
 
+def request_observation_by_place(place: str) -> str:
+    """
+    Get the latest weather information by place name.
+
+    :param place: Place name (e.g. Kaisaniemi, Helsinki)
+    :return: Latest weather information
+    """
+    params = _create_params(RequestType.OBSERVATION, 10, place=place)
+    return _send_request(params)
+
+
 # pylint: disable=too-many-arguments,too-many-positional-arguments
 def _create_params(request_type: RequestType,
                    timestep_minutes: int,


### PR DESCRIPTION
Unfortunately observation data cannot be fetched using coordinates and the station id cannot be resolved by using coordinates.
Luckily the FMI's opendata API allows to fetch the observation data from the closest station using `place`. 